### PR TITLE
ES5 option is now set per default

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
JSHint seems to be throwing an error:

```
>> ES5 option is now set per default
```

[And it's most likely because of this JSHint Issue](https://github.com/jshint/jshint/issues/1137)

So I think erasing that flag should deserve a conversation
