### PR TITLE
Eases up the regex for parseHtml

### DIFF
--- a/tasks/include_source.js
+++ b/tasks/include_source.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
 
 	// Parses input HTML and returns an array of include statements and their position.
 	var parseHtml = function(source) {
-		var re = /<!--\s+include:\s+(.*)\s+-->/gi,
+		var re = /<!---?\s*include:\s+(.*)\s*-?--\s*>/gi,
 			matches,
 			results = [];
 


### PR DESCRIPTION
3 purposeful changes to the regex based on [w3 syntax](http://www.w3.org/TR/REC-html40/intro/sgmltut.html#h-3.2.4):
- To have multiple or no spaces between comment and comment delimiters
  
  ```
  <!-- include... -->
  <!--include...-->
  ```
- To add a dash after and before comment delimiters
  
  ```
  <!-- --> 
  <!--- --->
  ```
- Have spaces between comment close delimiter and markup delimiter
  
  ```
  --> 
  -- >
  ```
