### PR TITLE
use global config to parse template variables in basePath strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
     },
 
     // Configuration to be run (and then tested).
-    include_source: {
+    includeSource: {
       default_options: {
         options: {
         },
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'include_source', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'includeSource', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/tasks/include_source.js
+++ b/tasks/include_source.js
@@ -87,6 +87,7 @@ module.exports = function(grunt) {
 		if (includeOptions.basePath) {
 			basePath = includeOptions.basePath;
 		}
+		basePath = grunt.template.process(basePath, grunt.config.get());
 		grunt.log.debug('Resolving files on base path "' + basePath + '"...');
 		grunt.log.debug('Include options: ' + util.inspect(includeOptions));
 


### PR DESCRIPTION
When overriding a basePath in a template, this allows for variagles from `grunt.config.get` to be used. Example

``` javascript
grunt.initConfig({
    buildDir: 'build/',
    includeSource: {
        options: {
            basePath: '<%= buildDir %>/js/app'
            baseUrl: 'js/app/'
        },
        all: {
            '<%= buildDir %>/index/html': ['<%= buildDir %>/index/html']
        }
    }
})
```

``` html
<!-- include: "type": "css", "basePath": "<%= buildDir %>/css", "baseUrl": "css/", "files": "**/*.css" -->
<!-- include: "type": "js", "basePath": "<%= buildDir %>/js/vendor", "baseUrl": "js/vendor/", "files": "**/*.js" -->
<!-- include: "type": "js", "files": "**/*.js" -->

```

In this case, all of the `<%= buildDir %>` tags become `'build/'` before looking for files.
