### PR TITLE
replacing all {filePath} instances and adding {filePathDecoded}

### DIFF
--- a/tasks/includeSource.js
+++ b/tasks/includeSource.js
@@ -208,7 +208,10 @@ module.exports = function(grunt) {
 				var	includeFragments = [];
 				files.forEach(function(file) {
 					grunt.log.debug('Including file "' + file + '".');
-					includeFragments.push(typeTemplates[include.options.type].replace('{filePath}', url.resolve(include.options.baseUrl || options.baseUrl, file)));
+					includeFragments.push(typeTemplates[include.options.type]
+						.replace(/\{filePath\}/g, url.resolve(include.options.baseUrl || options.baseUrl, file))
+						.replace(/\{filePathDecoded\}/g, decodeURI(url.resolve(include.options.baseUrl || options.baseUrl, file)))
+						);
 				});
 
 				var includeFragment = includeFragments.join(sep);


### PR DESCRIPTION
I used grunt-include-source to create a list of hyperlinks to html files. I made 2 changes to suit my case.
1. Replaced all instances of the {filePath} token instead of just the first (although I don't need it any more, I think I might soon.)
2. Added a new token for {filePathDecoded} to write the decodeURI version of the path.

The intent is to produce a template: &lt;a href="{filePath}"&gt;{filePathDecoded}&lt;/a&gt;
