### PR TITLE
Add support for "target" include option.

### DIFF
--- a/tasks/includeSource.js
+++ b/tasks/includeSource.js
@@ -203,7 +203,6 @@ module.exports = function(grunt) {
 	// Register the task.
 	grunt.registerMultiTask('includeSource', 'Include lists of files into your source files automatically.', function() {
 		grunt.log.debug('Starting task "includeSource"...');
-
 		var options = this.options({
 			basePath: '',
 			baseUrl: '',
@@ -283,7 +282,7 @@ module.exports = function(grunt) {
 
 			includes.forEach(function(include, includeIndex) {
 				var files = [];
-				if (options.target !== include.options.target) {
+				if (include.options.target && options.target !== include.options.target) {
 					grunt.log.debug('Include target is "' + include.options.target + '" and task target is "' + options.target + '", skipping include.');
 				} else {
 					files = resolveFiles(options, include.options);

--- a/tasks/includeSource.js
+++ b/tasks/includeSource.js
@@ -210,6 +210,7 @@ module.exports = function(grunt) {
 			templates: {},
 			typeMappings: {}
 		});
+		options.target = this.target;
 
 		var typeMappings = extendr.clone(defaultTypeMappings);
 		extendr.extend(typeMappings, options.typeMappings);
@@ -281,7 +282,12 @@ module.exports = function(grunt) {
 			grunt.log.debug('Found ' + includes.length + ' include statement(s).');
 
 			includes.forEach(function(include, includeIndex) {
-				var files = resolveFiles(options, include.options);
+				var files = [];
+				if (options.target !== include.options.target) {
+					grunt.log.debug('Include target is "' + include.options.target + '" and task target is "' + options.target + '", skipping include.');
+				} else {
+					files = resolveFiles(options, include.options);
+				}
 				orderFiles(files, include.options);
 	
 				var sep = os.EOL,


### PR DESCRIPTION
I wanted to write something like the following:
```
<!-- include: "target": "dev", "type": "js", "files": ["dist/lib/*.js", "dist/js/gameApp.js", "dist/js/*.js", "dist/shared/*.js"] -->
<!-- include: "target": "prod", "type": "js", "files": ["dist/client.min.js"] -->
```
where include is conditionally executed according to the task target.
My grunfile.js is:
```
includeSource: {
	options: {
		basePath: './',
		baseUrl: '',
		templates: {
			html: {
				js: '<script src="{filePath}"></script>'
			}
		}
	},
	dev: {
		files: {
			'dist/dev/game.html': 'html/game.html'
		}
	},
	prod: {
		files: {
			'dist/prod/game.html': 'html/game.html'
		}
	}
}
```